### PR TITLE
benchmark: add scheduling test

### DIFF
--- a/benchmark/scheduler_bench_test.go
+++ b/benchmark/scheduler_bench_test.go
@@ -1,0 +1,128 @@
+package benchmark
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/apiserver"
+	"k8s.io/kubernetes/pkg/client/record"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/master"
+	"k8s.io/kubernetes/plugin/pkg/admission/admit"
+	"k8s.io/kubernetes/plugin/pkg/scheduler"
+	_ "k8s.io/kubernetes/plugin/pkg/scheduler/algorithmprovider"
+	"k8s.io/kubernetes/plugin/pkg/scheduler/factory"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+// BenchmarkScheduling100Nodes0Pods benchmarks the scheduling rate
+// when the cluster has 100 nodes and 0 scheduled pods
+func BenchmarkScheduling100Nodes0Pods(b *testing.B) {
+	benchmarkScheduling(100, 0, b)
+}
+
+// BenchmarkScheduling100Nodes1000Pods benchmarks the scheduling rate
+// when the cluster has 100 nodes and 1000 scheduled pods
+func BenchmarkScheduling100Nodes1000Pods(b *testing.B) {
+	benchmarkScheduling(100, 1000, b)
+}
+
+// BenchmarkScheduling1000Nodes0Pods benchmarks the scheduling rate
+// when the cluster has 1000 nodes and 0 scheduled pods
+func BenchmarkScheduling1000Nodes0Pods(b *testing.B) {
+	benchmarkScheduling(1000, 0, b)
+}
+
+// BenchmarkScheduling1000Nodes10000Pods benchmarks the scheduling rate
+// when the cluster has 1000 nodes and 1000 scheduled pods
+func BenchmarkScheduling1000Nodes1000Pods(b *testing.B) {
+	benchmarkScheduling(1000, 1000, b)
+}
+
+func benchmarkScheduling(n, p int, b *testing.B) {
+	etcdStorage, err := framework.NewEtcdStorage()
+	if err != nil {
+		b.Fatalf("Couldn't create etcd storage: %v", err)
+	}
+	expEtcdStorage, err := framework.NewExtensionsEtcdStorage(nil)
+	if err != nil {
+		b.Fatalf("Unexpected error: %v", err)
+	}
+
+	storageDestinations := master.NewStorageDestinations()
+	storageDestinations.AddAPIGroup("", etcdStorage)
+	storageDestinations.AddAPIGroup("extensions", expEtcdStorage)
+
+	storageVersions := make(map[string]string)
+	storageVersions[""] = testapi.Default.Version()
+	storageVersions["extensions"] = testapi.Extensions.GroupAndVersion()
+
+	framework.DeleteAllEtcdKeys()
+
+	var m *master.Master
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		m.Handler.ServeHTTP(w, req)
+	}))
+	defer s.Close()
+
+	m = master.New(&master.Config{
+		StorageDestinations:   storageDestinations,
+		KubeletClient:         client.FakeKubeletClient{},
+		EnableCoreControllers: true,
+		EnableLogsSupport:     false,
+		EnableUISupport:       false,
+		EnableIndex:           true,
+		APIPrefix:             "/api",
+		Authorizer:            apiserver.NewAlwaysAllowAuthorizer(),
+		AdmissionControl:      admit.NewAlwaysAdmit(),
+		StorageVersions:       storageVersions,
+	})
+
+	c := client.NewOrDie(&client.Config{
+		Host:         s.URL,
+		GroupVersion: testapi.Default.GroupVersion(),
+		QPS:          5000.0,
+		Burst:        5000,
+	})
+
+	schedulerConfigFactory := factory.NewConfigFactory(c, nil)
+	schedulerConfig, err := schedulerConfigFactory.Create()
+	if err != nil {
+		b.Fatalf("Couldn't create scheduler config: %v", err)
+	}
+
+	eventBroadcaster := record.NewBroadcaster()
+	schedulerConfig.Recorder = eventBroadcaster.NewRecorder(api.EventSource{Component: "scheduler"})
+	eventBroadcaster.StartRecordingToSink(c.Events(""))
+	scheduler.New(schedulerConfig).Run()
+
+	defer close(schedulerConfig.StopEverything)
+
+	// prepare N nodes with P pods.
+	makeNNodes(c, n)
+	numPods := p
+	makeNPods(c, numPods)
+	for {
+		scheduled := schedulerConfigFactory.ScheduledPodLister.Store.List()
+		if len(scheduled) >= numPods {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	// start benchmark
+	b.ResetTimer()
+	makeNPods(c, b.N)
+	for {
+		scheduled := schedulerConfigFactory.ScheduledPodLister.Store.List()
+		if len(scheduled) >= numPods+b.N {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	b.StopTimer()
+}


### PR DESCRIPTION
example output:

Add a test to schedule 10K pods over 1000nodes.

The test will print out the second rate.

```
1s rate: 19 total: 154
2s rate: 20 total: 174
3s rate: 20 total: 194
4s rate: 20 total: 214
5s rate: 18 total: 232
6s rate: 19 total: 251
7s rate: 19 total: 270
8s rate: 19 total: 289
9s rate: 18 total: 307
10s rate: 20 total: 327
11s rate: 19 total: 346
12s rate: 19 total: 365
13s rate: 19 total: 384
14s rate: 20 total: 404
15s rate: 19 total: 423
16s rate: 18 total: 441
17s rate: 19 total: 460
18s rate: 19 total: 479
19s rate: 19 total: 498
20s rate: 12 total: 510
21s rate: 19 total: 529
22s rate: 18 total: 547
23s rate: 18 total: 565
24s rate: 18 total: 583
25s rate: 18 total: 601
26s rate: 17 total: 618
27s rate: 18 total: 636
28s rate: 18 total: 654
29s rate: 17 total: 671
30s rate: 18 total: 689
31s rate: 18 total: 707
32s rate: 18 total: 725
33s rate: 17 total: 742
34s rate: 18 total: 760
35s rate: 18 total: 778
36s rate: 17 total: 795
37s rate: 18 total: 813
38s rate: 17 total: 830
39s rate: 17 total: 847
40s rate: 16 total: 863
41s rate: 17 total: 880
42s rate: 17 total: 897
43s rate: 16 total: 913
44s rate: 17 total: 930
45s rate: 16 total: 946
46s rate: 17 total: 963
47s rate: 16 total: 979
48s rate: 16 total: 995
49s rate: 16 total: 1011
50s rate: 17 total: 1028
51s rate: 16 total: 1044
52s rate: 16 total: 1060
53s rate: 16 total: 1076
54s rate: 17 total: 1093
55s rate: 16 total: 1109
```
