### PR TITLE
Add subdir 'kubemark' for each result

### DIFF
--- a/metrics/publisher/README.md
+++ b/metrics/publisher/README.md
@@ -5,9 +5,6 @@ Metrics publisher takes a kubemark density test log (we might extend this in the
 
 Input is the kubemark log gcloud storage location.
 
-Because we are running nightly jobs, the unit of storage granularity is day. Cloud storage directory layout for one publication will look like:
-```sh
-{$bucket_name}/kubemark/{$date: 2015-11-27}/
-```
+Because we are running nightly jobs, the unit of storage granularity is day. Cloud storage directory layout is defined in [publish_gcloud_storage.sh](./publish_gcloud_storage.sh)
 
 See metrics results in [metrics-kscale](https://console.developers.google.com/storage/browser/metrics-kscale/)

--- a/metrics/publisher/publish.sh
+++ b/metrics/publisher/publish.sh
@@ -6,6 +6,7 @@ set -o pipefail
 
 KUBEMARK_LOG_GCLOUD_LOC=$1
 KUBEMARK_LOCAL_FILE="kubemark-log.txt"
+KUBEMARK_REPORT_DIR="kubemark"
 
 if ! command -v logplot >/dev/null 2>&1; then
   echo "Please install logplot (github.com/coreos/kscale/logplot)"
@@ -21,10 +22,13 @@ trap cleanup EXIT
 
 # Copy kubemark log from cloud
 pushd "${TEMP}"
-	gsutil cp "${KUBEMARK_LOG_GCLOUD_LOC}" "${KUBEMARK_LOCAL_FILE}"
-	# Generate reports (plots) and publish them
-	logplot -f "${KUBEMARK_LOCAL_FILE}"
-	echo "All files:" $(ls *)
+	mkdir "${KUBEMARK_REPORT_DIR}"
+	pushd "${KUBEMARK_REPORT_DIR}"
+		gsutil cp "${KUBEMARK_LOG_GCLOUD_LOC}" "${KUBEMARK_LOCAL_FILE}"
+		# Generate reports (plots) and publish them
+		logplot -f "${KUBEMARK_LOCAL_FILE}"
+		echo "kubemark reports:" $(ls *)
+	popd
 popd
 
 ./publish_gcloud_storage.sh "${TEMP}"

--- a/metrics/publisher/publish_gcloud_storage.sh
+++ b/metrics/publisher/publish_gcloud_storage.sh
@@ -11,8 +11,9 @@ set -o pipefail
 REPORTS_DIR=$1
 BUCKET_NAME="metrics-kscale"
 DATE_FORMAT=$(date +"%Y-%m-%d")
-GCLOUD_STORAGE_FORMAT="gs://${BUCKET_NAME}/kubemark/${DATE_FORMAT}"
+GCLOUD_STORAGE_FORMAT="gs://${BUCKET_NAME}/results/${DATE_FORMAT}"
 
 pushd "${REPORTS_DIR}"
-       gsutil cp * "${GCLOUD_STORAGE_FORMAT}"
+	echo "uploading files..."
+    gsutil cp -r ./ "${GCLOUD_STORAGE_FORMAT}"
 popd


### PR DESCRIPTION
The directory name on gcloud storage in changed from "xxx/kubemark/2015-11-27/" to "xxx/results/2015-11-27/" because we will extend it with integration results and any other results we want in the future. To avoid confusion, we had better rename it. Thanks!
