### PR TITLE
minor refactor & remove wait group to see actual rates

### DIFF
--- a/benchmark/scheduler_bench_test.go
+++ b/benchmark/scheduler_bench_test.go
@@ -29,13 +29,12 @@ func BenchmarkScheduling1000Nodes1000Pods(b *testing.B) {
 	benchmarkScheduling(1000, 1000, b)
 }
 
-func benchmarkScheduling(n, p int, b *testing.B) {
+func benchmarkScheduling(numNodes, numPods int, b *testing.B) {
 	schedulerConfigFactory, finalFunc := mustSetupScheduler()
 	defer finalFunc()
 	c := schedulerConfigFactory.Client
 
-	makeNodes(c, n)
-	numPods := p
+	makeNodes(c, numNodes)
 	makePods(c, numPods)
 	for {
 		scheduled := schedulerConfigFactory.ScheduledPodLister.Store.List()

--- a/benchmark/scheduler_test.go
+++ b/benchmark/scheduler_test.go
@@ -17,13 +17,13 @@ func TestScheduling1000Nodes10KPods(t *testing.T) {
 	defer destroyFunc()
 	c := schedulerConfigFactory.Client
 
-	numPods := 1000
-	numNodes := 10000
+	numPods := 10000
+	numNodes := 1000
 	makeNodes(c, numNodes)
 	makePods(c, numPods)
 
-	start := time.Now()
 	prev := 0
+	start := time.Now()
 	for {
 		scheduled := schedulerConfigFactory.ScheduledPodLister.Store.List()
 		fmt.Printf("%ds rate: %d total: %d\n", time.Since(start)/time.Second, len(scheduled)-prev, len(scheduled))


### PR DESCRIPTION
Previously, makePods() would wait until all CreatePods request sent. When result showed up the first time, there are already many pods scheduled:

```
=== RUN   TestScheduling1000Nodes10KPods
0s rate: 170 total: 170
1s rate: 4 total: 184
```

After removing the wait group, 

```
=== RUN   TestScheduling1000Nodes10KPods
0s rate: 0 total: 0
1s rate: 5 total: 5
2s rate: 12 total: 17
```

We don't need to wait group either because the loop checks all pods are scheduled and it's kinda like a wait group itself.

At the mean time, some minor fixes. :)
