### PR TITLE
Separate project dir names for uploading differnt jobs' results

### DIFF
--- a/metrics/publisher/publish.sh
+++ b/metrics/publisher/publish.sh
@@ -6,6 +6,7 @@ set -o pipefail
 
 KUBEMARK_LOG_FILE=$1
 KUBEMARK_REPORT_DIR="kubemark"
+kUBEMARK_PROJECT_NAME=${kUBEMARK_PROJECT_NAME:-"default"}
 
 if ! command -v logplot >/dev/null 2>&1; then
   echo "Please install logplot (github.com/coreos/kscale/logplot)"
@@ -21,14 +22,14 @@ trap cleanup EXIT
 
 # Copy kubemark log from cloud
 pushd "${TEMP}"
-	mkdir "${KUBEMARK_REPORT_DIR}"
-	pushd "${KUBEMARK_REPORT_DIR}"
+  mkdir -p "${KUBEMARK_REPORT_DIR}/${kUBEMARK_PROJECT_NAME}"
+  pushd "${KUBEMARK_REPORT_DIR}/${kUBEMARK_PROJECT_NAME}"
     log_file=$(basename ${KUBEMARK_LOG_FILE})
     cp "${KUBEMARK_LOG_FILE}" "${log_file}"
-		# Generate reports (plots) and publish them
-		logplot -f "${log_file}"
-		echo "kubemark reports:" $(ls *)
-	popd
+    # Generate reports (plots) and publish them
+    logplot -f "${log_file}"
+    echo "kubemark reports:" $(ls *)
+  popd
 popd
 
 # assumes that helper script are within the same dir


### PR DESCRIPTION
Currently the dir of nightly build results looks like:

```
results/${date}/kubemark/...
```

With this change it will have separate dirs for different jobs:

```
results/${date}/kubemark/1knodes/...
results/${date}/kubemark/100nodes/...
```
